### PR TITLE
fix(readme): name of setting @tmux-last-capture-key

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ A regex pattern to identify command separator. Required.
 set -g @tmux-last-prompt-pattern '> '
 ```
 
-### @tmux-last-capture-key
+### @tmux-last-key
 
-Set's the key that should be bound to open the last captured command output. Defaults to `t`.
+The key that should be bound to open the last command output. Defaults to `t`.
 
 ```tmux
-set -g @tmux-last-capture-key t
+set -g @tmux-last-key t
 ```
 
 ### @tmux-last-prompt-lines

--- a/README.md
+++ b/README.md
@@ -18,12 +18,12 @@ A regex pattern to identify command separator. Required.
 set -g @tmux-last-prompt-pattern '> '
 ```
 
-### @tmux-last-command-key
+### @tmux-last-capture-key
 
-Set's the key that should be bound to open the last command output. Defaults to `t`.
+Set's the key that should be bound to open the last captured command output. Defaults to `t`.
 
 ```tmux
-set -g @tmux-last-command-key t
+set -g @tmux-last-capture-key t
 ```
 
 ### @tmux-last-prompt-lines

--- a/tmux-last.tmux
+++ b/tmux-last.tmux
@@ -2,7 +2,7 @@
 
 CURRENT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
-KEY=$(tmux show-option -gqv @tmux-last-capture-key)
+KEY=$(tmux show-option -gqv @tmux-last-key)
 KEY=${KEY:-t}
 
 PROMPT_PATTERN=$(tmux show-option -gqv @tmux-last-prompt-pattern)


### PR DESCRIPTION
Setting wasn't read by the same key as in the readme