### PR TITLE
fix(pager): fallback to less only if pager_cmd and pager aren't set

### DIFF
--- a/plugin.sh
+++ b/plugin.sh
@@ -2,7 +2,7 @@
 
 # Get the custom page or use the default system pager as a fallback
 PAGER_CMD=${PAGER_CMD:-"$PAGER"}
-PAGER_CMD=${PAGER:-less}
+PAGER_CMD=${PAGER_CMD:-less}
 
 # Allow prompts with more than one line
 PROMPT_LINES=${PROMPT_LINES:-1}


### PR DESCRIPTION
With the current implementation, if `PAGER_CMD` is set, we fallback to `less` when `PAGER` isn't.